### PR TITLE
Update import syntax for GNOME 48+

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,21 +1,35 @@
 'use strict';
 
-const { Clutter, Gio, Meta, Shell } = imports.gi;
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Preferences } from './lib/preferences.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Extension = ExtensionUtils.getCurrentExtension();
-const { Preferences } = Extension.imports.lib.preferences;
+export default class BetterDesktopZoomExtension extends Extension {
+    enable() {
+        this._impl = new ExtensionImpl(this);
+        this._impl.enable();
+    }
+
+    disable() {
+        this._impl.disable();
+        this._impl = null;
+    }
+}
 
 class ExtensionImpl {
-    constructor() {
+    constructor(extension) {
+        this._extension = extension;
         this._keyMagnifierEnabled = `screen-magnifier-enabled`;
         this._keyZoomFactor = `mag-factor`;
     }
 
     enable() {
-        this._preferences = new Preferences();
+        this._preferences = new Preferences(this._extension);
 
         this._a11ySettings = new Gio.Settings({
             schema_id: `org.gnome.desktop.a11y.applications`,
@@ -26,12 +40,15 @@ class ExtensionImpl {
 
         this._addKeybindings();
 
-        global.stage.connectObject(`scroll-event`, (...[, event]) => {
+        global.stage.connectObject(`scroll-event`, (actor, event) => {
             return this._handleGlobalStageScrollEvent(event);
         }, this);
 
+        this._originalScroll = Main.wm.handleWorkspaceScroll;
         Main.wm.handleWorkspaceScroll = (event) => {
-            return this._handleGlobalStageScrollEvent(event) || Object.getPrototypeOf(Main.wm).handleWorkspaceScroll.call(Main.wm, event);
+            if (this._handleGlobalStageScrollEvent(event) === Clutter.EVENT_STOP)
+                return true;
+            return this._originalScroll.call(Main.wm, event);
         };
     }
 

--- a/lib/preferences.js
+++ b/lib/preferences.js
@@ -1,14 +1,10 @@
 'use strict';
 
-const { GObject } = imports.gi;
+import GObject from 'gi://GObject';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-
-var Preferences = GObject.registerClass(
-class Preferences extends GObject.Object {
-    static [GObject.GTypeName] = `BetterDesktopZoom_Preferences`;
-
-    static [GObject.properties] = {
+export const Preferences = GObject.registerClass({
+    GTypeName: 'BetterDesktopZoom_Preferences',
+    Properties: {
         'zoomFactor': GObject.ParamSpec.double(
             `zoomFactor`, ``, ``,
             GObject.ParamFlags.READWRITE,
@@ -34,9 +30,10 @@ class Preferences extends GObject.Object {
             GObject.ParamFlags.READWRITE,
             `<Super>minus`
         ),
-    };
+    },
+}, class Preferences extends GObject.Object {
 
-    constructor() {
+    constructor(extension) {
         super();
 
         this._keyZoomFactor = `zoom-factor`;
@@ -45,8 +42,8 @@ class Preferences extends GObject.Object {
         this._keyZoomInShortcut = `zoom-in-shortcut`;
         this._keyZoomOutShortcut = `zoom-out-shortcut`;
 
-        this._settings = ExtensionUtils.getSettings();
-        this._settingsChangedHandlerId = this._settings.connect(`changed`, (...[, key]) => {
+        this._settings = extension.getSettings();
+        this._settingsChangedHandlerId = this._settings.connect('changed', (...[, key]) => {
             switch (key) {
                 case this._keyZoomFactor: {
                     this.notify(`zoomFactor`);
@@ -68,14 +65,15 @@ class Preferences extends GObject.Object {
                     this.notify(`zoomOutShortcut`);
                     break;
                 }
-                default:
-                    break;
             }
         });
     }
 
     destroy() {
-        this._settings.disconnect(this._settingsChangedHandlerId);
+        if (this._settingsChangedHandlerId) {
+            this._settings.disconnect(this._settingsChangedHandlerId);
+            this._settingsChangedHandlerId = 0;
+        }
     }
 
     get zoomFactor() {

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
     "description": "A better experience with the GNOME magnifier",
     "url": "https://github.com/popov895/better-desktop-zoom",
     "version": 4,
-    "shell-version": ["42", "43", "44"],
+    "type": "extension",
+    "shell-version": ["45", "46", "47", "48", "49"],
     "settings-schema": "org.gnome.shell.extensions.better-desktop-zoom",
     "donations": {
         "custom": "https://github.com/popov895/popov895"

--- a/prefs.js
+++ b/prefs.js
@@ -1,23 +1,22 @@
 'use strict';
 
-const { Adw, Gdk, GLib, GObject, Gtk } = imports.gi;
+import Adw from 'gi://Adw';
+import Gdk from 'gi://Gdk';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Extension = ExtensionUtils.getCurrentExtension();
-const { Preferences } = Extension.imports.lib.preferences;
+import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { Preferences } from './lib/preferences.js';
 
-const _ = (text, context) => {
-    return context ? ExtensionUtils.pgettext(context, text) : ExtensionUtils.gettext(text);
-};
-
-const ShortcutWindow = GObject.registerClass(
-class ShortcutWindow extends Adw.Window {
-    static [GObject.signals] = {
+const ShortcutWindow = GObject.registerClass({
+    GTypeName: 'BetterDesktopZoom_ShortcutWindow',
+    Signals: {
         'shortcut': {
             param_types: [GObject.TYPE_STRING],
         },
-    };
-
+    },
+}, class ShortcutWindow extends Adw.Window {
     constructor(parent) {
         super({
             content: new Adw.StatusPage({
@@ -59,8 +58,9 @@ class ShortcutWindow extends Adw.Window {
     }
 });
 
-const ShortcutRow = GObject.registerClass(
-class ShortcutRow extends Adw.ActionRow {
+const ShortcutRow = GObject.registerClass({
+    GTypeName: 'BetterDesktopZoom_ShortcutRow',
+}, class ShortcutRow extends Adw.ActionRow {
     constructor(title, preferences, property) {
         super({
             title: title,
@@ -70,7 +70,7 @@ class ShortcutRow extends Adw.ActionRow {
         this._property = property;
 
         this.activatable_widget = new Gtk.ShortcutLabel({
-            disabled_text: _(`Disabled`, `Keyboard shortcut is disabled`),
+            disabled_text: _(`Disabled`),
             valign: Gtk.Align.CENTER,
         });
         this._preferences.bind_property(
@@ -95,105 +95,104 @@ class ShortcutRow extends Adw.ActionRow {
     }
 });
 
-var init = () => {
-    ExtensionUtils.initTranslations(Extension.uuid);
-};
+export default class BetterDesktopZoomPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        window._preferences = new Preferences(this);
 
-var fillPreferencesWindow = (window) => {
-    window._preferences = new Preferences();
-    window.connect(`close-request`, () => {
-        window._preferences.destroy();
-    });
+        window.connect('close-request', () => {
+            window._preferences.destroy();
+        });
 
-    const zoomFactorSpinBox = new Gtk.SpinButton({
-        adjustment: new Gtk.Adjustment({
-            lower: 1.1,
-            upper: 2,
-            step_increment: 0.1,
-        }),
-        digits: 2,
-        valign: Gtk.Align.CENTER,
-    });
-    window._preferences.bind_property(
-        `zoomFactor`,
-        zoomFactorSpinBox,
-        `value`,
-        GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
-    );
+        const zoomFactorSpinBox = new Gtk.SpinButton({
+            adjustment: new Gtk.Adjustment({
+                lower: 1.1,
+                upper: 2,
+                step_increment: 0.1,
+            }),
+            digits: 2,
+            valign: Gtk.Align.CENTER,
+        });
+        window._preferences.bind_property(
+            'zoomFactor',
+            zoomFactorSpinBox,
+            'value',
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
+        );
 
-    const zoomFactorRow = new Adw.ActionRow({
-        activatable_widget: zoomFactorSpinBox,
-        title: _(`Zoom factor`),
-    });
-    zoomFactorRow.add_suffix(zoomFactorSpinBox);
+        const zoomFactorRow = new Adw.ActionRow({
+            activatable_widget: zoomFactorSpinBox,
+            title: _('Zoom factor'),
+        });
+        zoomFactorRow.add_suffix(zoomFactorSpinBox);
 
-    const generalGroup = new Adw.PreferencesGroup({
-        title: _(`General`, `General options`),
-    });
-    generalGroup.add(zoomFactorRow);
+        const generalGroup = new Adw.PreferencesGroup({
+            title: _('General'),
+        });
+        generalGroup.add(zoomFactorRow);
 
-    const scrollToZoomSwitch = new Gtk.Switch({
-        valign: Gtk.Align.CENTER,
-    });
-    window._preferences.bind_property(
-        `scrollToZoom`,
-        scrollToZoomSwitch,
-        `active`,
-        GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
-    );
+        const scrollToZoomSwitch = new Gtk.Switch({
+            valign: Gtk.Align.CENTER,
+        });
+        window._preferences.bind_property(
+            'scrollToZoom',
+            scrollToZoomSwitch,
+            'active',
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
+        );
 
-    const scrollToZoomRow = new Adw.ActionRow({
-        activatable_widget: scrollToZoomSwitch,
-        title: _(`Use scroll gesture to zoom desktop`),
-    });
-    scrollToZoomRow.add_suffix(scrollToZoomSwitch);
+        const scrollToZoomRow = new Adw.ActionRow({
+            activatable_widget: scrollToZoomSwitch,
+            title: _('Use scroll gesture to zoom desktop'),
+        });
+        scrollToZoomRow.add_suffix(scrollToZoomSwitch);
 
-    const scrollToZoomModifierKeysDropDown = new Gtk.DropDown({
-        model: Gtk.StringList.new([
-            `Super + Ctrl`,
-            `Super + Alt`,
-            `Super + Shift`,
-        ]),
-        valign: Gtk.Align.CENTER,
-    });
-    window._preferences.bind_property(
-        `scrollToZoomModifierKeys`,
-        scrollToZoomModifierKeysDropDown,
-        `selected`,
-        GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
-    );
+        const scrollToZoomModifierKeysDropDown = new Gtk.DropDown({
+            model: Gtk.StringList.new([
+                'Super + Ctrl',
+                'Super + Alt',
+                'Super + Shift',
+            ]),
+            valign: Gtk.Align.CENTER,
+        });
+        window._preferences.bind_property(
+            'scrollToZoomModifierKeys',
+            scrollToZoomModifierKeysDropDown,
+            'selected',
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE
+        );
 
-    const scrollToZoomModifierKeysRow = new Adw.ActionRow({
-        activatable_widget: scrollToZoomModifierKeysDropDown,
-        title: _(`Modifier keys for scroll gesture`),
-    });
-    scrollToZoomModifierKeysRow.add_suffix(scrollToZoomModifierKeysDropDown);
+        const scrollToZoomModifierKeysRow = new Adw.ActionRow({
+            activatable_widget: scrollToZoomModifierKeysDropDown,
+            title: _('Modifier keys for scroll gesture'),
+        });
+        scrollToZoomModifierKeysRow.add_suffix(scrollToZoomModifierKeysDropDown);
 
-    const scrollToZoomGroup = new Adw.PreferencesGroup({
-        title: _(`Scroll To Zoom`),
-        visible: GLib.getenv(`XDG_SESSION_TYPE`) === `wayland`,
-    });
-    scrollToZoomGroup.add(scrollToZoomRow);
-    scrollToZoomGroup.add(scrollToZoomModifierKeysRow);
+        const scrollToZoomGroup = new Adw.PreferencesGroup({
+            title: _('Scroll To Zoom'),
+            visible: GLib.getenv('XDG_SESSION_TYPE') === 'wayland',
+        });
+        scrollToZoomGroup.add(scrollToZoomRow);
+        scrollToZoomGroup.add(scrollToZoomModifierKeysRow);
 
-    const keybindingGroup = new Adw.PreferencesGroup({
-        title: _(`Keyboard Shortcuts`),
-    });
-    keybindingGroup.add(new ShortcutRow(
-        _(`Zoom in`),
-        window._preferences,
-        `zoomInShortcut`
-    ));
-    keybindingGroup.add(new ShortcutRow(
-        _(`Zoom out`),
-        window._preferences,
-        `zoomOutShortcut`
-    ));
+        const keybindingGroup = new Adw.PreferencesGroup({
+            title: _('Keyboard Shortcuts'),
+        });
+        keybindingGroup.add(new ShortcutRow(
+            _('Zoom in'),
+            window._preferences,
+            'zoomInShortcut'
+        ));
+        keybindingGroup.add(new ShortcutRow(
+            _('Zoom out'),
+            window._preferences,
+            'zoomOutShortcut'
+        ));
 
-    const page = new Adw.PreferencesPage();
-    page.add(generalGroup);
-    page.add(scrollToZoomGroup);
-    page.add(keybindingGroup);
+        const page = new Adw.PreferencesPage();
+        page.add(generalGroup);
+        page.add(scrollToZoomGroup);
+        page.add(keybindingGroup);
 
-    window.add(page);
-};
+        window.add(page);
+    }
+}


### PR DESCRIPTION
These (AI-assisted) changes update to the [newer import syntax](https://gjs.guide/extensions/overview/imports-and-modules.html) for compatibility with GNOME 48+. This is a more comprehensive and future-proof fix than #8 to address #11 .

Tested with GNOME 49 on Ubuntu 25.10.